### PR TITLE
Add warning to RawValue docs regarding untagged enums

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -27,6 +27,8 @@ use serde::ser::{Serialize, SerializeStruct, Serializer};
 /// [dependencies]
 /// serde_json = { version = "1.0", features = ["raw_value"] }
 /// ```
+/// 
+/// For [technical reasons](https://github.com/serde-rs/json/issues/497), `RawValue` can't be used with untagged enums at the moment. Trying to deserialize to an untagged enum with `RawValue`, therefore, always fails with an error.
 ///
 /// # Example
 ///


### PR DESCRIPTION
Hi,

This adds a warning to the docs of `RawValue` for [this bug](https://github.com/serde-rs/json/issues/497) (deserializing to an untagged enum with `RawValue` always fails).

Because there is basically [no usable information if deserializing to an untagged enum failes](https://github.com/serde-rs/serde/issues/773), a note like this would be useful to Rust beginners like me (it took me more than one hour to find out what the problem was).